### PR TITLE
Feat/issue#7 uber post

### DIFF
--- a/src/main/java/sopt/uber/api/controller/UberController.java
+++ b/src/main/java/sopt/uber/api/controller/UberController.java
@@ -1,0 +1,25 @@
+package sopt.uber.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sopt.uber.api.dto.req.UberReq;
+import sopt.uber.core.common.response.CommonResponse;
+import sopt.uber.core.common.util.ResponseUtil;
+import sopt.uber.core.service.UberService;
+
+@RestController
+@RequestMapping("/uber")
+public class UberController {
+
+    private final UberService uberService;
+
+    public UberController(UberService uberService) {
+        this.uberService = uberService;
+    }
+
+    @PostMapping("/location")
+    public ResponseEntity<CommonResponse<Void>> createUber(@RequestBody UberReq req) {
+        uberService.createUber(req);
+        return ResponseUtil.success(null);
+    }
+}

--- a/src/main/java/sopt/uber/api/controller/UberController.java
+++ b/src/main/java/sopt/uber/api/controller/UberController.java
@@ -17,7 +17,7 @@ public class UberController {
         this.uberService = uberService;
     }
 
-    @PostMapping("/location")
+    @PostMapping("/v1/location")
     public ResponseEntity<CommonResponse<Void>> createUber(@RequestBody UberReq req) {
         uberService.createUber(req);
         return ResponseUtil.success(null);

--- a/src/main/java/sopt/uber/api/dto/req/UberReq.java
+++ b/src/main/java/sopt/uber/api/dto/req/UberReq.java
@@ -1,0 +1,4 @@
+package sopt.uber.api.dto.req;
+
+public record UberReq(String departures, String destination) {
+}

--- a/src/main/java/sopt/uber/api/exception/ErrorCode.java
+++ b/src/main/java/sopt/uber/api/exception/ErrorCode.java
@@ -4,9 +4,13 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 요청 형식을 확인해주세요."),
+
+    SAME_LOCATION(HttpStatus.BAD_REQUEST, "출발지와 목적지는 같을 수 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 URL입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+
 
     private final HttpStatus httpStatus;
     private final String msg;

--- a/src/main/java/sopt/uber/api/exception/ErrorCode.java
+++ b/src/main/java/sopt/uber/api/exception/ErrorCode.java
@@ -4,8 +4,8 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 요청 형식을 확인해주세요."),
-
     SAME_LOCATION(HttpStatus.BAD_REQUEST, "출발지와 목적지는 같을 수 없습니다."),
+    INVALID_LOCATION(HttpStatus.BAD_REQUEST, "출발지와 도착지 모두 입력해주세요."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 URL입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");

--- a/src/main/java/sopt/uber/core/domain/Uber.java
+++ b/src/main/java/sopt/uber/core/domain/Uber.java
@@ -1,0 +1,25 @@
+package sopt.uber.core.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Uber {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String departures;
+    private String destination;
+
+    public Uber() {
+
+    }
+
+    public Uber(String departures, String destination) {
+        this.departures = departures;
+        this.destination = destination;
+    }
+}

--- a/src/main/java/sopt/uber/core/domain/Uber.java
+++ b/src/main/java/sopt/uber/core/domain/Uber.java
@@ -1,9 +1,6 @@
 package sopt.uber.core.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 @Entity
 public class Uber {
@@ -11,7 +8,11 @@ public class Uber {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private String departures;
+
+    @Column(nullable = false)
     private String destination;
 
     // 객체 생성을 제한적으로 허용하기 위한 접근 제어자 변경

--- a/src/main/java/sopt/uber/core/domain/Uber.java
+++ b/src/main/java/sopt/uber/core/domain/Uber.java
@@ -14,7 +14,8 @@ public class Uber {
     private String departures;
     private String destination;
 
-    public Uber() {
+    // 객체 생성을 제한적으로 허용하기 위한 접근 제어자 변경
+    protected Uber() {
 
     }
 

--- a/src/main/java/sopt/uber/core/repository/UberRepository.java
+++ b/src/main/java/sopt/uber/core/repository/UberRepository.java
@@ -1,0 +1,9 @@
+package sopt.uber.core.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sopt.uber.core.domain.Uber;
+
+@Repository
+public interface UberRepository extends JpaRepository<Uber, Long> {
+}

--- a/src/main/java/sopt/uber/core/service/UberService.java
+++ b/src/main/java/sopt/uber/core/service/UberService.java
@@ -19,6 +19,11 @@ public class UberService {
     }
 
     public void createUber(UberReq req) {
+
+        if (req.departures() == null || req.destination() == null) {
+            throw new BusinessException(ErrorCode.INVALID_LOCATION);
+        }
+
         if (req.departures().equals(req.destination())) {
             throw new BusinessException(ErrorCode.SAME_LOCATION);
         }

--- a/src/main/java/sopt/uber/core/service/UberService.java
+++ b/src/main/java/sopt/uber/core/service/UberService.java
@@ -19,16 +19,18 @@ public class UberService {
     }
 
     public void createUber(UberReq req) {
+        String departures = req.departures() != null ? req.departures().trim() : null;
+        String destination = req.destination() != null ? req.destination().trim() : null;
 
-        if (req.departures() == null || req.destination() == null) {
+        if (departures == null || departures.isBlank() || destination == null || destination.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_LOCATION);
         }
 
-        if (req.departures().equals(req.destination())) {
+        if (departures.equals(destination)) {
             throw new BusinessException(ErrorCode.SAME_LOCATION);
         }
 
-        Uber uber = new Uber(req.departures(), req.destination());
+        Uber uber = new Uber(departures, destination);
         uberRepository.save(uber);
     }
 }

--- a/src/main/java/sopt/uber/core/service/UberService.java
+++ b/src/main/java/sopt/uber/core/service/UberService.java
@@ -1,0 +1,29 @@
+package sopt.uber.core.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.uber.api.dto.req.UberReq;
+import sopt.uber.api.exception.BusinessException;
+import sopt.uber.api.exception.ErrorCode;
+import sopt.uber.core.domain.Uber;
+import sopt.uber.core.repository.UberRepository;
+
+@Service
+@Transactional
+public class UberService {
+
+    private final UberRepository uberRepository;
+
+    public UberService(UberRepository uberRepository) {
+        this.uberRepository = uberRepository;
+    }
+
+    public void createUber(UberReq req) {
+        if (req.departures().equals(req.destination())) {
+            throw new BusinessException(ErrorCode.SAME_LOCATION);
+        }
+
+        Uber uber = new Uber(req.departures(), req.destination());
+        uberRepository.save(uber);
+    }
+}


### PR DESCRIPTION
## Issue Number
- Close #7 
## Key Changes
1. Uber 도메인에 관한 클래스를 생성했습니다.
2. UberReq 값을 post 요청하면 출발지와 도착지를 저장할 수 있습니다.
    - 출발지와 도착지가 null 값이거나, 동일할 때에 대한 예외 처리를 구현했습니다.

## To Reviewers
출발지 또는 도착지가 null 값을 가질 때, @NotBlank만으로는 원하는 메시지와 상태 코드로 제어하기 어려워서 서비스 레이어에서 직접 유효성 검사 후 커스텀 에러 코드를 던지는 방식으로 구현하였습니다.

혹시 이보다 더 나은 방법이나, 예를 들어 도메인 내부에서 유효성 검증하는 방식이나, 컨트롤러 단에서 @Validated로 처리하는 방식이 더 적절할지 의견 주시면 감사하겠습니다!

또한, 현재는 null 값만 검증하고 있는데, 빈 문자열을 입력받을 때의 예외 처리도 함께하는 게 좋을지 궁금합니다.
그럴 경우 어떤식으로 구성하는 게 나을지 의견 부탁드립니다.

## PR CheckList
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] Postman 확인 완료
- [x] Reviewer 추가 및 단톡방에 알리기