### PR TITLE
[fix] Taxi db 변경에 따른 쿼리문 변경

### DIFF
--- a/src/main/java/sopt/uber/core/repository/TaxiRepository.java
+++ b/src/main/java/sopt/uber/core/repository/TaxiRepository.java
@@ -16,6 +16,6 @@ public interface TaxiRepository extends JpaRepository<Taxi, Long> {
     List<TaxiRes> findAllTaxiListResponse();
 
     @Query("SELECT new sopt.uber.api.dto.res.TaxiRes(t.id, t.type, t.min, t.max, t.guests, t.comment) " +
-            "FROM Taxi t WHERE t.id IN (2, 3)")
+            "FROM Taxi t WHERE t.id IN (3, 4)")
     List<TaxiRes> findAllCaseTaxiListResponse();
 }


### PR DESCRIPTION
## Issue Number
- Close #23 
## Key Changes
1. Taxi db 변경에 따라서 TaxiList와 CaseTaxiList의 값을 각각 id값이 1, 2와 3, 4인 Taxi로 할당될 수 있도록 쿼리문을 변경하였습니다.
## To Reviewers
## PR CheckList
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] Postman 확인 완료
- [x] Reviewer 추가 및 단톡방에 알리기